### PR TITLE
Generate webp variants for tent uploads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "multer": "^1.4.5-lts.1",
         "nodemailer": "^6.9.13",
         "puppeteer": "^23.4.0",
+        "sharp": "^0.33.4",
         "socket.io": "^4.7.5"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "jsonwebtoken": "^9.0.2",
     "multer": "^1.4.5-lts.1",
     "nodemailer": "^6.9.13",
+    "sharp": "^0.33.4",
     "puppeteer": "^23.4.0",
     "socket.io": "^4.7.5"
   },

--- a/prisma/init/init.ts
+++ b/prisma/init/init.ts
@@ -7,6 +7,7 @@ import bcrypt from 'bcryptjs';
 import { TentsData } from './data/tents';
 import { ProductsCategoriesData, ProductsData } from './data/products';
 import { ExperiencesCategoriesData, ExperiencesData } from './data/experiences';
+import { processImage } from '../../src/lib/image';
 
 const getImageFiles = (folderPath: string) => {
   // Define common image file extensions
@@ -38,21 +39,19 @@ const moveImagesToSubFolder = async (ObjectId: number, category: string, subfold
   // Get the list of image names from the source folder
   const imageNames = getImageFiles(path.join(__dirname, `./files/${category}/${subfolderName}`));
 
+  const shouldGenerateSmall = category === 'tents';
+
   for (const image of imageNames) {
     const oldPath = path.join(__dirname, `./files/${category}/${subfolderName}/`, image);
-    const ext = path.extname(image); // Get the original extension
+    const uniqueSuffix = `${Date.now()}-${Math.floor(Math.random() * 10000)}`;
 
-    // Create a new name using the current timestamp and the original extension
-    //const newImageName = `${Date.now()}${ext}`;
-    const uniqueSuffix = `${Date.now()}-${Math.floor(Math.random() * 10000)}`; // Add randomness
-    const newImageName = `${uniqueSuffix}${ext}`;
-    const newPath = path.join(subFolderPath, newImageName);
+    const { normalPath } = await processImage(oldPath, subFolderPath, {
+      generateSmall: shouldGenerateSmall,
+      outputFileName: uniqueSuffix,
+      removeSource: false,
+    });
 
-    // Copy the file to the new location with the new name
-    await fs.promises.copyFile(oldPath, newPath);
-
-    // Push the new path relative to the public/images directory
-    newPaths.push(newPath.replace(path.join(__dirname, '../../'), ''));
+    newPaths.push(normalPath.replace(path.join(__dirname, '../../'), '').replace(/\\/g, '/'));
   }
 
   return newPaths;

--- a/src/config/email/helper.ts
+++ b/src/config/email/helper.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { ReserveDto } from '../../dto/reserve';
 import * as utils from '../../lib/utils';
+import { getImageUrl, ImageVariant } from '../../lib/image';
 
 // Load SMTP configuration from environment variables
 const CLIENT_HOSTNAME = process.env.CLIENT_HOSTNAME || 'http://localhost:5174';
@@ -20,10 +21,12 @@ const replaceAllPlaceholders = (tpl: string, data: Record<string, string>) => {
   return tpl.replace(re, (_, key) => data[key]);
 };
 
-const formatImagePath = (image: string): string => {
-  image = image.replace(/\\/g, '/'); // Assign the result of replace to image
-  image = image.replace("public", `${CLIENT_HOSTNAME}/backend-public`); // Same here
-  return image;
+const formatImagePath = (image: string, variant: ImageVariant = 'normal'): string => {
+  if (!image) {
+    return image;
+  }
+
+  return getImageUrl(image, { size: variant, basePath: `${CLIENT_HOSTNAME}/backend-public` });
 };
 
 type TemplateData = {
@@ -414,7 +417,7 @@ export const generateReservationTemplate = (title: string, greeting_message_1: s
                                     <td align="center" class="email-reserve-block-image"
                                       ><a target="_blank"
                                         href="${CLIENT_HOSTNAME}"><img class="email-reserve-block-image-img"
-                                          src=${`${formatImagePath(tent.tentDB?.images[0] ?? "none")}`}
+                                          src=${`${formatImagePath(tent.tentDB?.images[0] ?? '', 'small')}`}
                                           alt=${"image-reserve-" + tent.idTent}"image-reserve" ></a></td>
                                   </tr>
                                 </tbody>

--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -1,0 +1,138 @@
+import fs from 'fs';
+import path from 'path';
+import sharp from 'sharp';
+
+export type ImageVariant = 'normal' | 'small';
+
+export const NORMAL_VARIANT_DIR = '600px';
+export const SMALL_VARIANT_DIR = '150px';
+
+interface ProcessImageOptions {
+  generateSmall?: boolean;
+  removeSource?: boolean;
+  outputFileName?: string;
+  normalWidth?: number;
+  smallWidth?: number;
+}
+
+const ensureDirectory = async (directoryPath: string) => {
+  await fs.promises.mkdir(directoryPath, { recursive: true });
+};
+
+const getOutputFileName = (sourcePath: string, outputFileName?: string): string => {
+  const baseName = outputFileName
+    ? path.parse(outputFileName).name
+    : path.parse(sourcePath).name;
+
+  return `${baseName}.webp`;
+};
+
+export const processImage = async (
+  sourcePath: string,
+  destinationBasePath: string,
+  options: ProcessImageOptions = {}
+): Promise<{ normalPath: string; smallPath?: string }> => {
+  const {
+    generateSmall = false,
+    removeSource = true,
+    outputFileName,
+    normalWidth = 600,
+    smallWidth = 150,
+  } = options;
+
+  const filename = getOutputFileName(sourcePath, outputFileName);
+
+  const normalDir = path.join(destinationBasePath, NORMAL_VARIANT_DIR);
+  await ensureDirectory(normalDir);
+
+  const normalFullPath = path.join(normalDir, filename);
+
+  const sourceImage = sharp(sourcePath);
+
+  await sourceImage
+    .clone()
+    .resize({ width: normalWidth, height: normalWidth, fit: 'inside', withoutEnlargement: true })
+    .webp({ quality: 85 })
+    .toFile(normalFullPath);
+
+  let smallFullPath: string | undefined;
+
+  if (generateSmall) {
+    const smallDir = path.join(destinationBasePath, SMALL_VARIANT_DIR);
+    await ensureDirectory(smallDir);
+
+    smallFullPath = path.join(smallDir, filename);
+
+    await sourceImage
+      .clone()
+      .resize({ width: smallWidth, height: smallWidth, fit: 'inside', withoutEnlargement: true })
+      .webp({ quality: 85 })
+      .toFile(smallFullPath);
+  }
+
+  if (removeSource) {
+    try {
+      await fs.promises.unlink(sourcePath);
+    } catch (error) {
+      const nodeError = error as NodeJS.ErrnoException;
+      if (nodeError?.code !== 'ENOENT') {
+        throw error;
+      }
+    }
+  }
+
+  return {
+    normalPath: normalFullPath,
+    smallPath: smallFullPath,
+  };
+};
+
+const replaceVariantSegment = (imagePath: string, from: string, to: string): string => {
+  const normalized = imagePath.replace(/\\/g, '/');
+  const fromSegment = `/${from}/`;
+  if (normalized.includes(fromSegment)) {
+    return normalized.replace(fromSegment, `/${to}/`);
+  }
+  return normalized;
+};
+
+export const getVariantPath = (imagePath: string, variant: ImageVariant = 'normal'): string => {
+  if (!imagePath) {
+    return imagePath;
+  }
+
+  if (variant === 'small') {
+    return replaceVariantSegment(imagePath, NORMAL_VARIANT_DIR, SMALL_VARIANT_DIR);
+  }
+
+  return imagePath.replace(/\\/g, '/');
+};
+
+interface GetImageUrlOptions {
+  size?: ImageVariant;
+  basePath?: string;
+  publicPrefix?: string;
+}
+
+export const getImageUrl = (imagePath: string, options: GetImageUrlOptions = {}): string => {
+  if (!imagePath) {
+    return imagePath;
+  }
+
+  const { size = 'normal', basePath, publicPrefix = 'public' } = options;
+
+  let variantPath = getVariantPath(imagePath, size);
+
+  if (!basePath) {
+    return variantPath;
+  }
+
+  const normalized = variantPath.replace(/\\/g, '/');
+  const prefix = publicPrefix.replace(/\\/g, '/');
+
+  if (normalized.startsWith(`${prefix}/`)) {
+    return normalized.replace(prefix, basePath);
+  }
+
+  return normalized;
+};


### PR DESCRIPTION
## Summary
- add a sharp-based image processor to create 600px normal and 150px tent variants when handling uploads
- expose an image helper for variant URLs and update reservation emails to use the small image
- update the database seed process and dependencies to produce and consume the new image structure

## Testing
- not run (sharp dependency is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e5787b50f08320bfe3883bd063e015